### PR TITLE
fix: Use user-cookie auth for the graph route

### DIFF
--- a/workspaces/upptime/.changeset/curvy-crabs-appear.md
+++ b/workspaces/upptime/.changeset/curvy-crabs-appear.md
@@ -1,0 +1,6 @@
+---
+'@philips-software/backstage-plugin-upptime-frontend': minor
+'@philips-software/backstage-plugin-upptime-backend': minor
+---
+
+Update to use cookie auth for graph images

--- a/workspaces/upptime/plugins/upptime-backend/src/plugin.ts
+++ b/workspaces/upptime/plugins/upptime-backend/src/plugin.ts
@@ -22,8 +22,17 @@ export const upptimeBackend = createBackendPlugin({
         httpRouter: coreServices.httpRouter,
         reader: coreServices.urlReader,
         auth: coreServices.auth,
+        httpAuth: coreServices.httpAuth,
       },
-      async init({ logger, config, discovery, httpRouter, reader, auth }) {
+      async init({
+        logger,
+        config,
+        discovery,
+        httpRouter,
+        reader,
+        auth,
+        httpAuth,
+      }) {
         const catalog = new CatalogClient({
           discoveryApi: discovery,
         });
@@ -34,6 +43,7 @@ export const upptimeBackend = createBackendPlugin({
             config,
             reader,
             auth,
+            httpAuth,
           }),
         );
         httpRouter.addAuthPolicy({

--- a/workspaces/upptime/plugins/upptime-backend/src/service/router.test.ts
+++ b/workspaces/upptime/plugins/upptime-backend/src/service/router.test.ts
@@ -10,7 +10,7 @@ import { Entity } from '@backstage/catalog-model';
 import { createRouter } from './router';
 import { ConfigReader } from '@backstage/config';
 import { CatalogApi } from '@backstage/catalog-client';
-import { AuthService } from '@backstage/backend-plugin-api';
+import { AuthService, HttpAuthService } from '@backstage/backend-plugin-api';
 
 describe('createRouter', () => {
   let app: express.Express;
@@ -29,6 +29,9 @@ describe('createRouter', () => {
   const auth = {
     getPluginRequestToken: jest.fn(),
     getOwnServiceCredentials: jest.fn(),
+  };
+  const httpAuth = {
+    issueUserCookie: jest.fn(),
   };
   const config = new ConfigReader({
     upptime: {
@@ -51,6 +54,7 @@ describe('createRouter', () => {
       config,
       reader: mockUrlReader,
       auth: auth as unknown as AuthService,
+      httpAuth: httpAuth as unknown as HttpAuthService,
     });
     app = express().use(router);
   });

--- a/workspaces/upptime/plugins/upptime-backend/src/service/standaloneServer.ts
+++ b/workspaces/upptime/plugins/upptime-backend/src/service/standaloneServer.ts
@@ -5,7 +5,7 @@ import { Logger } from 'winston';
 import { createRouter } from './router';
 import { ConfigReader } from '@backstage/config';
 import { CatalogApi } from '@backstage/catalog-client';
-import { AuthService } from '@backstage/backend-plugin-api';
+import { AuthService, HttpAuthService } from '@backstage/backend-plugin-api';
 
 export interface ServerOptions {
   port: number;
@@ -50,7 +50,9 @@ export async function startStandaloneServer(
     getPluginRequestToken: jest.fn().mockResolvedValue({ token: 'mytoken' }),
     getOwnServiceCredentials: jest.fn(),
   } as unknown as AuthService;
-
+  const httpAuth = {
+    issueUserCookie: jest.fn(),
+  } as unknown as HttpAuthService;
   logger.debug('Starting application server...');
   const router = await createRouter({
     logger,
@@ -58,6 +60,7 @@ export async function startStandaloneServer(
     config,
     reader: mockUrlReader,
     auth,
+    httpAuth,
   });
 
   let service = createServiceBuilder(module)

--- a/workspaces/upptime/plugins/upptime-frontend/src/api/UpptimeApi.ts
+++ b/workspaces/upptime/plugins/upptime-frontend/src/api/UpptimeApi.ts
@@ -16,4 +16,6 @@ export type UpptimeApi = {
   getSummary(entity: CompoundEntityRef): Promise<UpptimeSummary | undefined>;
 
   getSummaryImageUrl(entity: CompoundEntityRef): Promise<string>;
+
+  getCookie(): Promise<void>;
 };

--- a/workspaces/upptime/plugins/upptime-frontend/src/api/UpptimeClient.ts
+++ b/workspaces/upptime/plugins/upptime-frontend/src/api/UpptimeClient.ts
@@ -40,6 +40,19 @@ export class UpptimeClient implements UpptimeApi {
     return undefined;
   }
 
+  async getCookie(): Promise<void> {
+    const { token: idToken } = await this.identityApi.getCredentials();
+
+    const apiUrl = `${await this.discoveryApi.getBaseUrl('upptime')}`;
+
+    await fetch(`${apiUrl}/cookie`, {
+      headers: {
+        'Content-Type': 'application/json',
+        ...(idToken && { Authorization: `Bearer ${idToken}` }),
+      },
+    });
+  }
+
   async getSummaryImageUrl(entity: CompoundEntityRef): Promise<string> {
     const apiUrl = `${await this.discoveryApi.getBaseUrl('upptime')}`;
 

--- a/workspaces/upptime/plugins/upptime-frontend/src/components/EntityUpptimeCard/EntityUpptimeCard.tsx
+++ b/workspaces/upptime/plugins/upptime-frontend/src/components/EntityUpptimeCard/EntityUpptimeCard.tsx
@@ -74,6 +74,9 @@ export const EntityUpptimeCard = (props: EntityUpptimeCardProps) => {
 
   const { value: imageUrl } = useAsync(async () => {
     if (key) {
+      // we need to make sure we have a cookie before we request the image location
+      // the cookie is used to retrieve the image from the API instead of a bearer token
+      await upptimeApi.getCookie();
       return upptimeApi.getSummaryImageUrl(getCompoundEntityRef(entity));
     }
     return undefined;


### PR DESCRIPTION
Add an endpoint to the API to allow the plugin to retrieve a scoped cookie that can be used to request the image from the API using user-cookie authentication instead of a bearer token.

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Tests for new functionality and regression tests for bug fixes
