### PR TITLE
ci: Only commit and push changes if they exist

### DIFF
--- a/.github/workflows/automate_dependabot_changeset.yml
+++ b/.github/workflows/automate_dependabot_changeset.yml
@@ -58,5 +58,10 @@ jobs:
 
       - name: Commit Lockfile Changes
         run: |
-          git commit -am "Automated de-duplication of lockfile"
-          git push
+          # Check for changes
+          if ! git diff-index --quiet HEAD --; then
+            git commit -am "Automated de-duplication of lockfile"
+            git push
+          else
+              echo "No changes to commit."
+          fi


### PR DESCRIPTION
To prevent failures we only want to commit and push lock file changes if there have been some.