### PR TITLE
fix(confluence): remove divider from `ConfluenceResultListItem`

### DIFF
--- a/workspaces/confluence/.changeset/seven-stingrays-sit.md
+++ b/workspaces/confluence/.changeset/seven-stingrays-sit.md
@@ -1,0 +1,5 @@
+---
+'@philips-software/backstage-plugin-search-confluence-frontend': patch
+---
+
+Removed divider from ConfluenceResultListItem

--- a/workspaces/confluence/plugins/search-confluence-frontend/src/components/ConfluenceResultListItem/ConfluenceResultListItem.tsx
+++ b/workspaces/confluence/plugins/search-confluence-frontend/src/components/ConfluenceResultListItem/ConfluenceResultListItem.tsx
@@ -9,7 +9,6 @@ import {
   Box,
   Breadcrumbs,
   Chip,
-  Divider,
   ListItem,
   ListItemIcon,
   ListItemText,
@@ -136,20 +135,16 @@ export const ConfluenceResultListItem = ({
   );
 
   return (
-    <>
-      <ListItem alignItems="center">
-        <ListItemIcon title="Confluence document">
-          <ConfluenceSearchIcon />
-        </ListItemIcon>
-        <ListItemText
-          primary={title}
-          secondary={excerpt}
-          className={classes.itemText}
-          primaryTypographyProps={{ variant: 'h6' }}
-        />
-      </ListItem>
-
-      <Divider component="li" />
-    </>
+    <ListItem alignItems="center">
+      <ListItemIcon title="Confluence document">
+        <ConfluenceSearchIcon />
+      </ListItemIcon>
+      <ListItemText
+        primary={title}
+        secondary={excerpt}
+        className={classes.itemText}
+        primaryTypographyProps={{ variant: 'h6' }}
+      />
+    </ListItem>
   );
 };


### PR DESCRIPTION
This PR removes the divider from `ConfluenceResultListItem` since it acts as a duplicate divider. Especially if you have applied any sort of formatting, like we have, this can look really bad.

Before:

![Scherm­afbeelding 2024-11-15 om 16 03 14](https://github.com/user-attachments/assets/a3adb4ce-5d1d-4110-b048-c98c67b0bc0c)

After:

![Scherm­afbeelding 2024-11-15 om 16 13 21](https://github.com/user-attachments/assets/d03a8ebd-7cc2-4539-8742-61b933ca2dce)

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Screenshots attached (for UI changes)
